### PR TITLE
Set minimum buffer length to 1

### DIFF
--- a/DataStream.js
+++ b/DataStream.js
@@ -1479,3 +1479,9 @@ DataStream.prototype.writeType = function(t, v, struct) {
   }
 };
 
+// Export DataStream for amd environments
+if (typeof define === 'function' && define.amd) {
+    define('DataStream', [], function() {
+      return DataStream;
+    });
+  }


### PR DESCRIPTION
DataStream will crash with a byteOffset out of range error if you run the following code using node js and require.js

install node
install requirejs: npm install requirejs
Create an example file with the following: example.js

(function(requirejs){
    requirejs(['./DataStream'],function(){
        var ds = new DataStream();
    });
})(require('requirejs'));

Put example.js in the same directory as DataStream.js
From the command line run: node example.js

Crash

Fix:  Set minimum ArrayBuffer length to 1 when now defined
